### PR TITLE
Anpassung der Satzung in Jahresversammlung 2022

### DIFF
--- a/satzung
+++ b/satzung
@@ -1,14 +1,14 @@
 Satzung des Vereins „Opennet Initiative e.V.“
 Beschlossen in der E-Mail Abstimmung am 30. Oktober 2007
-Geändert und beschlossen von der Jahresversammlung am 02. Februar 2018
+Geändert und beschlossen von der Jahresversammlung am 04. Februar 2022
 §1 Name, Sitz und Geschäftsjahr
-1. Name: Der Verein führt den Namen „Opennet Initiative e. V“. Er ist in das Vereinsregister des
+1. Name: Der Verein führt den Namen „Opennet Initiative e.V.“. Er ist in das Vereinsregister des
 Amtsgerichts Rostock unter der Registernummer VR 2110 eingetragen
 2. Sitz: Der Verein hat seinen Sitz in Rostock.
 3. Geschäftsjahr: Das Geschäftsjahr des Vereins ist das Kalenderjahr.
 §2 Zweck des Vereins
 Der Zweck des Vereins ist die Förderung des Aufbaus einer freien und offenen
-Kommunikationsinfrastruktur (im folgenden offenes Netz oder Open Net genannt). Der Verein
+Kommunikationsinfrastruktur (im folgenden offenes Netz oder Opennet genannt). Der Verein
 erfüllt seine Zwecke insbesondere durch
 1. die Erarbeitung von Musterkonfigurationen, Regelwerken und Vertrags-bedingungen, die seinen
 Mitgliedern den selbständigen Betrieb eigenständiger, vom Verein unabhängiger offener Netze
@@ -72,10 +72,13 @@ erforderlich ist.
 9. Der Austritt aus dem Verein erfolgt durch schriftliche Erklärung an den Vorstand und ist nur
 zum Ende des jeweiligen Kalendermonats möglich. Eine Rückerstattung gezahlter Beiträge,
 insbesondere von Anteilen des Jahresbeitrags, ist ausgeschlossen.
-10. Ausschluß: Handelt ein Vereinsmitglied den Zielen und Zwecken des Vereins zuwider, verstößt
-es mehrfach oder schwerwiegend gegen die Leistungsordnung des Vereins oder ist es trotz
-Mahnung mehr als ein Quartal im Zahlungsrückstand, so kann die Mitgliederversammlung den
-Ausschluß des Mitglieds beschließen.
+10. Ausschluß: Handelt ein Vereinsmitglied den Zielen und Zwecken des Vereins zuwider,
+verstößt es mehrfach oder schwerwiegend gegen die Leistungsordnung des Vereins oder
+ist es trotz Mahnung mehr als ein Quartal im Zahlungsrückstand, so kann der Vorstand
+den Ausschluss des Mitglieds beschließen. Über den Ausschluss ist auf der nächsten
+Mitgliederversammlung zu informieren. Die ausgeschlossenen Mitglieder sind nicht in der 
+Einladung namentlich anzukündigen. Die Mitgliederversammlung kann den Beschluss des
+Vorstandes auf Antrag durch einfache Mehrheit aufheben.
 11. Wechsel der Art der Mitgliedschaft ist zum Ende des jeweiligen Kalendermonats möglich. 
 §5 Beiträge
 1. Die Höhe und Fälligkeit der Mitgliedsbeiträge ist in der Beitragsordnung des Vereins geregelt.
@@ -178,4 +181,4 @@ Rostock, den 30.10.2007
 Für den Vorstand
 Jan Conrads Christian Wedell
 Lothar Mickel Nils Heine 
-Diese Satzung tritt mit der Beschlussfassung der Jahresversammlung am 02. Februar 2018 in Kraft. 
+Diese Satzung tritt mit der Beschlussfassung der Jahresversammlung am 04. Februar 2022 in Kraft. 


### PR DESCRIPTION
Quelle = https://wiki.opennet-initiative.de/wiki/Jahresversammlung_2022#TOP_5_-_Weitere_Antr.C3.A4ge_und_Verschiedenes

Neue Formulierungen in der Satzung beschlossen 4. Februar 2022

§2 Zweck des Vereins

Der Zweck des Vereins ist die Förderung des Aufbaus einer freien und offenen
Kommunikationsinfrastruktur (im folgenden offenes Netz oder Opennet genannt).

§4 Mitglieder - 10. Ausschluss

Handelt ein Vereinsmitglied den Zielen und Zwecken des Vereins zuwider,
verstößt es mehrfach oder schwerwiegend gegen die Leistungsordnung des Vereins oder
ist es trotz Mahnung mehr als ein Quartal im Zahlungsrückstand, so kann der Vorstand
den Ausschluss des Mitglieds beschließen. Über den Ausschluss ist auf der nächsten
Mitgliederversammlung zu informieren. Die ausgeschlossenen Mitglieder sind nicht in der 
Einladung namentlich anzukündigen. Die Mitgliederversammlung kann den Beschluss des
Vorstandes auf Antrag durch einfache Mehrheit aufheben.